### PR TITLE
기타 에러 발생 시 재고 복구 하지 않는 문제 수정 및 예외 처리 블록 분리

### DIFF
--- a/src/main/java/com/hyoguoo/paymentplatform/payment/application/PaymentConfirmServiceImpl.java
+++ b/src/main/java/com/hyoguoo/paymentplatform/payment/application/PaymentConfirmServiceImpl.java
@@ -87,5 +87,6 @@ public class PaymentConfirmServiceImpl implements PaymentConfirmService {
 
     private void handleUnknownException(PaymentEvent paymentEvent) {
         paymentProcessorUseCase.markPaymentAsFail(paymentEvent);
+        orderedProductUseCase.increaseStockForOrders(paymentEvent.getPaymentOrderList());
     }
 }

--- a/src/test/java/com/hyoguoo/paymentplatform/payment/application/PaymentConfirmServiceImplTest.java
+++ b/src/test/java/com/hyoguoo/paymentplatform/payment/application/PaymentConfirmServiceImplTest.java
@@ -138,7 +138,7 @@ class PaymentConfirmServiceImplTest {
     }
 
     @Test
-    @DisplayName("재시도 불가능한 결제 오류 발생 시 예외를 던지고 재고를 복구한다.")
+    @DisplayName("재시도 불가능한 결제 오류 발생 시 결제를 실패 처리하고 재고를 복구한다.")
     void testConfirm_NonRetryableFailure() throws Exception {
         // given
         MockConfirmData mockConfirmData = getDefaultMockConfirmData();
@@ -188,6 +188,8 @@ class PaymentConfirmServiceImplTest {
 
         verify(mockPaymentProcessorUseCase, times(1))
                 .markPaymentAsFail(mockConfirmData.mockPaymentEvent());
+        verify(mockOrderedProductUseCase, times(1))
+                .increaseStockForOrders(mockConfirmData.mockPaymentEvent().getPaymentOrderList());
     }
 
     private record MockConfirmData(PaymentConfirmCommand paymentConfirmCommand, PaymentEvent mockPaymentEvent) {


### PR DESCRIPTION
- 기타 에러 발생 시 재고 복구 로직 호출
- 재고 처리 로직만 별도의 예외 처리 블록에서 수행
  - 두 번째 예외 블록에서 확정적으로 재고가 차감된 상태를 보장하기 위해 재고 차감 로직을 첫 번째 블록에서 처리