### PR TITLE
CI 린트 게이트 견고화 — PR 전수 차단 및 변경 파일 인라인 표시

### DIFF
--- a/.claude/skills/_shared/protocols/verify-round.md
+++ b/.claude/skills/_shared/protocols/verify-round.md
@@ -10,7 +10,7 @@ STATE 종결 → PR 생성까지 결정론적으로 처리한다.
 - **판정 수용**: Critic JSON `decision`만 기계적으로 읽는다.
 
 ## Participants
-- **Verifier** (Haiku) — 전체 `./gradlew test` 실행
+- **Verifier** (Haiku) — 전체 `./gradlew test` + 린트(`checkstyle` / `spotbugs`) 실행
 - **Critic** (Opus) — `verify-ready.md` 체크리스트 판정
 - **PR Manager** (Haiku) — `vc-round.md` 규칙에 따른 PR 생성/갱신
 
@@ -31,7 +31,8 @@ STATE 종결 → PR 생성까지 결정론적으로 처리한다.
 ## Flow
 
 ### Step 1 — Verifier
-- `./gradlew test` 실행 (전체)
+- `./gradlew test` 실행 (전체). 통합테스트 UP-TO-DATE 캐시 사각지대 회피 위해 `--rerun-tasks` 또는 명시 실행 권장.
+- **린트 게이트도 함께**: `./gradlew checkstyleMain checkstyleTest spotbugsMain --continue` (또는 `./gradlew check`). test 와 별도 task라 `test` 만으로는 unused import 등 린트 위반을 놓친다 — CI 가 PR 전수 게이트로 막으므로 로컬에서 선제 차단.
 - 실패 시 Implementer에게 복귀 (verify 중단)
 
 ### Step 2 — Context 문서 갱신

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
               file="$module/build/reports/checkstyle/${report}.xml"
               if [ -f "$file" ]; then
                 reviewdog -f=checkstyle -name="Checkstyle (${module}/${report})" \
-                  -reporter=github-pr-review -fail-on-error=true \
+                  -reporter=github-pr-review -filter-mode=file -fail-on-error=false \
                   < "$file"
               fi
             done
@@ -131,7 +131,7 @@ jobs:
             if [ -f "$file" ]; then
               python3 .github/scripts/spotbugs-to-rdjsonl.py "$file" "$module" \
                 | reviewdog -f=rdjsonl -name="SpotBugs (${module})" \
-                  -reporter=github-pr-review -fail-on-error=true
+                  -reporter=github-pr-review -filter-mode=file -fail-on-error=false
             fi
           done
 
@@ -143,8 +143,11 @@ jobs:
             const script = require('./.github/scripts/lint-summary.js');
             await script({ github, context });
 
-      - name: Fail on violations (push)
-        if: always() && github.event_name != 'pull_request'
+      - name: Fail on violations (lint gate)
+        # PR / push 모두 전수 게이트 — checkstyle/spotbugs task 가 위반 시 fail.
+        # reviewdog 는 인라인 안내(filter-mode=file)만 담당하고 차단은 이 게이트가 책임진다.
+        # reviewdog 필터 범위(변경 파일/라인) 사각지대와 무관하게 전수로 머지를 막는다.
+        if: always()
         run: |
           if [ "${{ steps.checkstyle.outcome }}" != "success" ] || \
              [ "${{ steps.spotbugs.outcome }}" != "success" ]; then


### PR DESCRIPTION
## 관련 이슈

Closes #85

## 배경

- PR에서 린트(checkstyle/spotbugs) 위반이 머지를 막지 못하는 구조였다. 빌드 실패 게이트가 푸시 이벤트에만 적용되고 PR은 인라인 코멘트 도구에만 의존
- 인라인 코멘트 도구의 기본 필터(추가된 라인만)는 "사용처 삭제로 기존 import/코드가 미사용 위반이 된" 케이스를 변경 라인으로 보지 않아 코멘트도, 차단도 누락
- 실제로 미사용 import 위반이 인라인 코멘트 없이 그대로 통과하는 사례 발생

## 변경 내용

- **전수 린트 게이트를 PR·푸시 모두 적용** — checkstyle/spotbugs task 결과가 위반이면 빌드 실패. 차단 책임을 게이트로 일원화해 인라인 도구의 필터 사각지대와 무관하게 머지를 막는다
- **인라인 코멘트 필터를 변경 파일 단위로 확대** + 차단 책임 분리 — 변경한 파일의 위반 위치를 정확히 표시하되, 통과/실패 판정은 게이트가 담당
- **로컬 검증 가이드에 린트 포함** — 검증 단계에서 테스트와 별도로 린트 task를 함께 돌려 푸시 전 1차 방어

## 검증

- 워크플로우 구조 변경(게이트 적용 범위 + 필터 모드). main 린트 무위반 baseline이라 전수 게이트 적용 시 기존 PR 영향 없음
- 게이트 동작은 후속 PR의 실제 위반 발생 시 확인

## 비고

- 린트 규칙 자체와 기존 코드 위반 일괄 정정은 범위 밖